### PR TITLE
Missing Starkware that's used for benchmark test

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "fast-check": "3.0.0",
     "micro-bmark": "0.3.0",
     "micro-should": "0.4.0",
+    "@starkware-industries/starkware-crypto-utils": "^0.0.2",
     "prettier": "2.8.3",
     "rollup": "2.75.5",
     "typescript": "4.7.3"


### PR DESCRIPTION
// benchmark/stark.js 
import * as starkwareCrypto from '@starkware-industries/starkware-crypto-utils';