### PR TITLE
ed25519: fix edwardsToMontgomery formula; implement edwardsToMontgomeryPriv

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,6 +5,7 @@ import './basic.test.js';
 import './nist.test.js';
 import './ed448.test.js';
 import './ed25519.test.js';
+import './ed25519-addons.test.js';
 import './secp256k1.test.js';
 import './secp256k1-schnorr.test.js';
 import './jubjub.test.js';


### PR DESCRIPTION
fixes #31

This fixes the formula used in `edwardsToMontgomery`.
I also implemented the equivalent transformation for private keys `edwardsToMontgomeryPriv` and added a bunch of tests.

Is there a reason `ed25519-addons.test.js` wasn't being run during `npm test` ? I included it as well.

My IDE rearranged the imports and whitespace to fit prettier rules. If that's an issue I can revert.