### PR TITLE
Specify supported node.js version range in manifest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
         "micro-should": "0.4.0",
         "prettier": "2.8.4",
         "typescript": "5.0.2"
+      },
+      "engines": {
+        "node": "16.x || >= 18.0.0"
       }
     },
     "node_modules/@noble/hashes": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "*.d.ts",
     "*.d.ts.map"
   ],
+  "engines": {
+    "node": "16.x || >= 18.0.0"
+  },
   "scripts": {
     "bench": "cd benchmark; node secp256k1.js; node curves.js; node ecdh.js; node hash-to-curve.js; node modular.js; node bls.js",
     "build": "tsc && tsc -p tsconfig.esm.json",


### PR DESCRIPTION
This adds that the supported Node.js version range to the package manifest to expose this information to tooling and users in a standardized way.

