### PR TITLE
fix: validate hash_to_field DST as stringOrUint8Array (closes #57)

### DIFF
--- a/src/abstract/hash-to-curve.ts
+++ b/src/abstract/hash-to-curve.ts
@@ -127,7 +127,7 @@ export function expand_message_xof(
  */
 export function hash_to_field(msg: Uint8Array, count: number, options: Opts): bigint[][] {
   validateObject(options, {
-    DST: 'string',
+    DST: 'stringOrUint8Array',
     p: 'bigint',
     m: 'isSafeInteger',
     k: 'isSafeInteger',

--- a/src/abstract/utils.ts
+++ b/src/abstract/utils.ts
@@ -246,6 +246,7 @@ const validatorFns = {
   function: (val: any) => typeof val === 'function',
   boolean: (val: any) => typeof val === 'boolean',
   string: (val: any) => typeof val === 'string',
+  stringOrUint8Array: (val: any) => typeof val === 'string' || val instanceof Uint8Array,
   isSafeInteger: (val: any) => Number.isSafeInteger(val),
   array: (val: any) => Array.isArray(val),
   field: (val: any, object: any) => (object as any).Fp.isValid(val),


### PR DESCRIPTION
No other ORed types in the validator list yet.
I suppose you could support some kinda operations for validators, but this KISS
Went with a generic name, so it can be reused for hexOrBytes too 