### PR TITLE
Add pure annotation to all calls to `twistedEdwards`

### DIFF
--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -123,7 +123,7 @@ const ed25519Defaults = {
   uvRatio,
 } as const;
 
-export const ed25519 = twistedEdwards(ed25519Defaults);
+export const ed25519 = /* @__PURE__ */ twistedEdwards(ed25519Defaults);
 
 function ed25519_domain(data: Uint8Array, ctx: Uint8Array, phflag: boolean) {
   if (ctx.length > 255) throw new Error('Context is too big');
@@ -135,8 +135,11 @@ function ed25519_domain(data: Uint8Array, ctx: Uint8Array, phflag: boolean) {
   );
 }
 
-export const ed25519ctx = twistedEdwards({ ...ed25519Defaults, domain: ed25519_domain });
-export const ed25519ph = twistedEdwards({
+export const ed25519ctx = /* @__PURE__ */ twistedEdwards({
+  ...ed25519Defaults,
+  domain: ed25519_domain,
+});
+export const ed25519ph = /* @__PURE__ */ twistedEdwards({
   ...ed25519Defaults,
   domain: ed25519_domain,
   prehash: sha512,

--- a/src/ed448.ts
+++ b/src/ed448.ts
@@ -130,9 +130,9 @@ const ED448_DEF = {
   uvRatio,
 } as const;
 
-export const ed448 = twistedEdwards(ED448_DEF);
+export const ed448 = /* @__PURE__ */ twistedEdwards(ED448_DEF);
 // NOTE: there is no ed448ctx, since ed448 supports ctx by default
-export const ed448ph = twistedEdwards({ ...ED448_DEF, prehash: shake256_64 });
+export const ed448ph = /* @__PURE__ */ twistedEdwards({ ...ED448_DEF, prehash: shake256_64 });
 
 export const x448 = /* @__PURE__ */ (() =>
   montgomery({

--- a/src/jubjub.ts
+++ b/src/jubjub.ts
@@ -11,7 +11,7 @@ import { Field } from './abstract/modular.js';
  * jubjub does not use EdDSA, so `hash`/sha512 params are passed because interface expects them.
  */
 
-export const jubjub = twistedEdwards({
+export const jubjub = /* @__PURE__ */ twistedEdwards({
   // Params: a, d
   a: BigInt('0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000'),
   d: BigInt('0x2a9318e74bfa2b48f5fd9207e6bd7fd4292d7f6d37579d2601065fd6d6343eb1'),


### PR DESCRIPTION
This PR makes it so that if you only use _one_ export:

```ts
import { ed25519 } from '@noble/curves`;
```

…then only the `twistedEdwards` call that constructs that export will remain after bundling and tree-shaking.

## Before

Before this change, the compiled bundle contains all the code that constructs `ed25519ph` and `ed25519ctx` remains.

```js
var ed25519 = twistedEdwards(ed25519Defaults);
function ed25519_domain(data, ctx, phflag) {
  if (ctx.length > 255)
    throw new Error("Context is too big");
  return concatBytes(utf8ToBytes("SigEd25519 no Ed25519 collisions"), new Uint8Array([phflag ? 1 : 0, ctx.length]), ctx, data);
}
twistedEdwards({ ...ed25519Defaults, domain: ed25519_domain });
twistedEdwards({
  ...ed25519Defaults,
  domain: ed25519_domain,
  prehash: sha512
});
```

## After

```js
var ed25519 = twistedEdwards(ed25519Defaults);
```