### PR TITLE
Improve `hexToBytes` performance

### DIFF
--- a/src/abstract/utils.ts
+++ b/src/abstract/utils.ts
@@ -44,7 +44,8 @@ export function hexToNumber(hex: string): bigint {
   return BigInt(hex === '' ? '0' : `0x${hex}`);
 }
 
-const enum HexCharCode {
+// We use very optimized technique to convert hex string to byte array
+const enum HexC {
   ZERO = 48, // 0
   NINE = 57, // 9
   A_UP = 65, // A
@@ -54,15 +55,10 @@ const enum HexCharCode {
 }
 
 function charCodeToBase16(char: number) {
-  if (char >= HexCharCode.ZERO && char <= HexCharCode.NINE) {
-    return char - HexCharCode.ZERO;
-  } else if (char >= HexCharCode.A_UP && char <= HexCharCode.F_UP) {
-    return char - (HexCharCode.A_UP - 10);
-  } else if (char >= HexCharCode.A_LO && char <= HexCharCode.F_LO) {
-    return char - (HexCharCode.A_LO - 10);
-  }
-
-  throw new Error('Invalid byte sequence.');
+  if (char >= HexC.ZERO && char <= HexC.NINE) return char - HexC.ZERO;
+  else if (char >= HexC.A_UP && char <= HexC.F_UP) return char - (HexC.A_UP - 10);
+  else if (char >= HexC.A_LO && char <= HexC.F_LO) return char - (HexC.A_LO - 10);
+  throw new Error('Invalid byte sequence');
 }
 
 /**
@@ -72,8 +68,9 @@ export function hexToBytes(hex: string): Uint8Array {
   if (typeof hex !== 'string') throw new Error('hex string expected, got ' + typeof hex);
   const len = hex.length;
   if (len % 2) throw new Error('padded hex string expected, got unpadded hex of length ' + len);
-  const array = new Uint8Array(len / 2);
-  for (let i = 0, j = 0, l = array.length; i < l; i++) {
+  const al = len / 2;
+  const array = new Uint8Array(al);
+  for (let i = 0, j = 0; i < al; i++) {
     const n1 = charCodeToBase16(hex.charCodeAt(j++));
     const n2 = charCodeToBase16(hex.charCodeAt(j++));
     array[i] = n1 * 16 + n2;

--- a/src/abstract/utils.ts
+++ b/src/abstract/utils.ts
@@ -44,6 +44,27 @@ export function hexToNumber(hex: string): bigint {
   return BigInt(hex === '' ? '0' : `0x${hex}`);
 }
 
+const enum HexCharCode {
+  ZERO = 48, // 0
+  NINE = 57, // 9
+  A_UP = 65, // A
+  F_UP = 70, // F
+  A_LO = 97, // a
+  F_LO = 102, // f
+}
+
+function charCodeToBase16(char: number) {
+  if (char >= HexCharCode.ZERO && char <= HexCharCode.NINE) {
+    return char - HexCharCode.ZERO;
+  } else if (char >= HexCharCode.A_UP && char <= HexCharCode.F_UP) {
+    return char - (HexCharCode.A_UP - 10);
+  } else if (char >= HexCharCode.A_LO && char <= HexCharCode.F_LO) {
+    return char - (HexCharCode.A_LO - 10);
+  }
+
+  throw new Error('Invalid byte sequence.');
+}
+
 /**
  * @example hexToBytes('cafe0123') // Uint8Array.from([0xca, 0xfe, 0x01, 0x23])
  */
@@ -52,12 +73,10 @@ export function hexToBytes(hex: string): Uint8Array {
   const len = hex.length;
   if (len % 2) throw new Error('padded hex string expected, got unpadded hex of length ' + len);
   const array = new Uint8Array(len / 2);
-  for (let i = 0; i < array.length; i++) {
-    const j = i * 2;
-    const hexByte = hex.slice(j, j + 2);
-    const byte = Number.parseInt(hexByte, 16);
-    if (Number.isNaN(byte) || byte < 0) throw new Error('Invalid byte sequence');
-    array[i] = byte;
+  for (let i = 0, j = 0, l = array.length; i < l; i++) {
+    const n1 = charCodeToBase16(hex.charCodeAt(j++));
+    const n2 = charCodeToBase16(hex.charCodeAt(j++));
+    array[i] = n1 * 16 + n2;
   }
   return array;
 }


### PR DESCRIPTION
## What this does
Rewrites `hexToBytes` function using char code approach to gain ~6x in performance.

## Benchmark
Benchmark results on a MacBook Air M1 and node v20:
```batch
 ✓ packages/crypto/src/coders/hex.bench.ts (6) 3583ms
   ✓ Decode hex to bytes (3) 3055ms
     name                                      hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · @noble/hashes implementation       25,861.49  0.0364  0.4523  0.0387  0.0381  0.0433  0.0540  0.3573  ±0.67%    12931  
   · @scure/base implementation          4,391.03  0.2167  0.6890  0.2277  0.2287  0.2810  0.5655  0.6118  ±0.66%     2196   slowest
   · @fleet-sdk/crypto implementation  173,810.56  0.0054  0.4406  0.0058  0.0057  0.0076  0.0093  0.0144  ±0.31%    86906   fastest

  @fleet-sdk/crypto implementation - packages/crypto/src/coders/hex.bench.ts > Decode hex to bytes
    6.72x faster than @noble/hashes implementation
    39.58x faster than @scure/base implementation
```

Benchmark code: https://github.com/fleet-sdk/fleet/blob/master/packages/crypto/src/coders/hex.bench.ts