### PR TITLE
Fix `weierstrassPoints` missing CURVE object

### DIFF
--- a/src/abstract/weierstrass.ts
+++ b/src/abstract/weierstrass.ts
@@ -123,6 +123,7 @@ function validatePointOpts<T>(curve: CurvePointsType<T>) {
 }
 
 export type CurvePointsRes<T> = {
+  CURVE: ReturnType<typeof validatePointOpts<T>>;
   ProjectivePoint: ProjConstructor<T>;
   normPrivateKeyToScalar: (key: PrivKey) => bigint;
   weierstrassEquation: (x: T) => T;

--- a/src/abstract/weierstrass.ts
+++ b/src/abstract/weierstrass.ts
@@ -188,7 +188,7 @@ export const DER = {
 // prettier-ignore
 const _0n = BigInt(0), _1n = BigInt(1), _2n = BigInt(2), _3n = BigInt(3), _4n = BigInt(4);
 
-export function weierstrassPoints<T>(opts: CurvePointsType<T>) {
+export function weierstrassPoints<T>(opts: CurvePointsType<T>): CurvePointsRes<T> {
   const CURVE = validatePointOpts(opts);
   const { Fp } = CURVE; // All curves has same field / group length as for now, but they can differ
 


### PR DESCRIPTION
`weierstrassPoints` returns the validated CURVE object, but it is not in `CurvePointsRes`. As a result, the CURVE objects of G1 and G2 in bls12-381 are not accessible.

This PR explicitly adds the CURVE object type in `CurvePointsRes`