### PR TITLE
meta: Indicate compatible Node.js versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "prettier": "3.3.2",
         "typescript": "5.5.2"
       },
+      "engines": {
+        "node": "^18 || ^20 || >=22"
+      },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "prettier": "3.3.2",
     "typescript": "5.5.2"
   },
+  "engines": {
+    "node": "^14.21.3 || ^16.20.2 || ^18 || ^20 || >=22"
+  },
   "sideEffects": false,
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
Indicate compatible and supported Node.js versions in package manifest via `engines.node`.  