### PR TITLE
wNAF, wNAFUnsafe: merge some logic, remove duplicate code

### DIFF
--- a/src/abstract/utils.ts
+++ b/src/abstract/utils.ts
@@ -10,7 +10,6 @@
 // won't be included into their bundle.
 const _0n = /* @__PURE__ */ BigInt(0);
 const _1n = /* @__PURE__ */ BigInt(1);
-const _2n = /* @__PURE__ */ BigInt(2);
 export type Hex = Uint8Array | string; // hex strings are accepted for simplicity
 export type PrivKey = Hex | bigint; // bigints are accepted to ease learning curve
 export type CHash = {
@@ -245,7 +244,7 @@ export function bitSet(n: bigint, pos: number, value: boolean): bigint {
  * Calculate mask for N bits. Not using ** operator with bigints because of old engines.
  * Same as BigInt(`0b${Array(i).fill('1').join('')}`)
  */
-export const bitMask = (n: number): bigint => (_2n << BigInt(n - 1)) - _1n;
+export const bitMask = (n: number): bigint => (_1n << BigInt(n)) - _1n;
 
 // DRBG
 


### PR DESCRIPTION
This code part is sensitive, because it handles private keys.

TODO:

- [ ] Investigate how precomputeMSMUnsafe can be simplified as well
- [ ] same for pippenger
- [ ] Investigate zero addition in "It's not obvious how this can fail, but still worth investigating later."
    - Seems like infinity point can easily be created
    - Fake points are created using predictable pattern: they fetch `[offsetF1.neg(), offsetF2, offsetF3.neg(), offsetF4...]` where offsetF = window*windowSize
    - This means we can construct a scalar which would trigger the conditions

Mirroring to:

* https://github.com/paulmillr/noble-secp256k1/commit/47cb1669b6e506ad66b35fe7d76132ae97465da2
* https://github.com/paulmillr/noble-ed25519/commit/6d54433d7e7012d4f9cabe84632cb1d95f1d0505