### PR TITLE
feat(ed25519): Add montgomeryToEdwardsPub for XEdDSA support

### DIFF
--- a/test/ed25519.helpers.js
+++ b/test/ed25519.helpers.js
@@ -1,2 +1,7 @@
 export { numberToBytesLE } from '../esm/abstract/utils.js';
-export { ed25519, ED25519_TORSION_SUBGROUP } from '../esm/ed25519.js';
+export {
+  ed25519,
+  ED25519_TORSION_SUBGROUP,
+  edwardsToMontgomeryPub,
+  montgomeryToEdwardsPub
+} from '../esm/ed25519.js';


### PR DESCRIPTION
Added the `montgomeryToEdwardsPub` function, which converts an X25519 (Montgomery) public key into an Ed25519 (Twisted Edwards) public key.

This functionality is essential for implementing protocols like Signal's XEdDSA, where a single master key is used to derive both an X25519 key for key agreement and an Ed25519 key for signing. While the public identity key is the X25519 key, signatures are created with the corresponding Ed25519 key.

To verify these signatures, a recipient must be able to convert the public X25519 key back into a valid Ed25519 public key. This function provides that missing piece, enabling the full signature verification workflow for such protocols directly within noble-curves.

A test case has been added to ensure that a key can be converted from Edwards to Montgomery and back, and that a signature can be successfully verified with the recovered key.