### PR TITLE
fix(bn254): update Python implementation link

### DIFF
--- a/src/bn254.ts
+++ b/src/bn254.ts
@@ -35,7 +35,7 @@ because it at least has specs:
     - https://github.com/arkworks-rs/curves/blob/master/bn254/src/lib.rs
 - Python implementations use different towers and produce different Fp12 outputs:
     - https://github.com/ethereum/py_pairing
-    - https://github.com/ethereum/execution-specs/blob/master/src/ethereum/crypto/alt_bn128.py
+    - https://github.com/ethereum/py_ecc/tree/main/py_ecc/bn128
 - Points are encoded differently in different implementations
 
 ### Params


### PR DESCRIPTION
Corrected the link to the Python implementation of bn128 in bn254.ts comments.
