### PR TITLE
fix: bls Fp2/Fp6/Fp12 isValid

### DIFF
--- a/src/abstract/tower.ts
+++ b/src/abstract/tower.ts
@@ -10,7 +10,7 @@
  * @module
  */
 /*! noble-curves - MIT License (c) 2022 Paul Miller (paulmillr.com) */
-import { bitGet, bitLen, concatBytes, notImplemented } from '../utils.ts';
+import { bitGet, concatBytes, notImplemented } from '../utils.ts';
 import * as mod from './modular.ts';
 import type { WeierstrassPoint, WeierstrassPointCons } from './weierstrass.ts';
 
@@ -177,12 +177,10 @@ class _Field2 implements mod.IField<Fp2> {
       Fp2mulByB: Tower12Opts['Fp2mulByB'];
     }> = {}
   ) {
-    const ORDER = Fp.ORDER;
-    const FP2_ORDER = ORDER * ORDER;
     this.Fp = Fp;
-    this.ORDER = FP2_ORDER;
-    this.BITS = bitLen(FP2_ORDER);
-    this.BYTES = Math.ceil(bitLen(FP2_ORDER) / 8);
+    this.ORDER = Fp.ORDER * Fp.ORDER; // TODO: unused, but need to verify
+    this.BITS = 2 * Fp.BITS;
+    this.BYTES = 2 * Fp.BYTES;
     this.isLE = Fp.isLE;
     this.ZERO = { c0: Fp.ZERO, c1: Fp.ZERO };
     this.ONE = { c0: Fp.ONE, c1: Fp.ZERO };
@@ -202,10 +200,8 @@ class _Field2 implements mod.IField<Fp2> {
     return num;
   }
   isValid({ c0, c1 }: Fp2) {
-    function isValidC(num: bigint, ORDER: bigint) {
-      return typeof num === 'bigint' && _0n <= num && num < ORDER;
-    }
-    return isValidC(c0, this.ORDER) && isValidC(c1, this.ORDER);
+    const { Fp } = this;
+    return Fp.isValid(c0) && Fp.isValid(c1);
   }
   is0({ c0, c1 }: Fp2) {
     return this.Fp.is0(c0) && this.Fp.is0(c1);

--- a/src/abstract/tower.ts
+++ b/src/abstract/tower.ts
@@ -178,7 +178,7 @@ class _Field2 implements mod.IField<Fp2> {
     }> = {}
   ) {
     this.Fp = Fp;
-    this.ORDER = Fp.ORDER * Fp.ORDER; // TODO: unused, but need to verify
+    this.ORDER = Fp.ORDER * Fp.ORDER; // TODO: verify if it's unused
     this.BITS = 2 * Fp.BITS;
     this.BYTES = 2 * Fp.BYTES;
     this.isLE = Fp.isLE;
@@ -607,7 +607,7 @@ class _Field12 implements Fp12Bls {
     const { Fp } = Fp2;
     this.Fp6 = Fp6;
 
-    this.ORDER = Fp2.ORDER; // TODO: verify if it's unuesd
+    this.ORDER = Fp2.ORDER; // TODO: verify if it's unused
     this.BITS = 2 * Fp6.BITS;
     this.BYTES = 2 * Fp6.BYTES;
     this.isLE = Fp6.isLE;

--- a/test/bn254.test.ts
+++ b/test/bn254.test.ts
@@ -9,7 +9,7 @@ import { default as seda } from './vectors/bn254/seda.js';
 const CROSS_PATH_GZ = './vectors/bn254/cross1000.json.gz'; // bundler hint: readFileSync('./test/bn254/cross1000.json.gz')
 
 describe('bn254', () => {
-  const { Fp2, Fp6, Fp12 } = bn254.fields;
+  const { Fp, Fp2, Fp6, Fp12 } = bn254.fields;
   should('Fp2', () => {
     const x = {
       c0: 9175274256610746571769806138441460978067247223835479920885065774008687444157n,
@@ -19,6 +19,11 @@ describe('bn254', () => {
       c0: 18745010300259074081467171901089189864928626882998930881106784720284549917403n,
       c1: 6755404584462298611753346784665337222239198745905936344431516651379215797104n,
     };
+    eql(Fp2.isValid({ c0: 0n, c1: 0n }), true);
+    eql(Fp2.isValid(x), true);
+    eql(Fp2.isValid(y), true);
+    eql(Fp2.isValid({ c0: Fp.ORDER, c1: 0n }), false);
+    eql(Fp2.isValid({ c0: 0n, c1: Fp.ORDER }), false);
     const mul = Fp2.mul(x, y);
     eql(mul, {
       c0: 14915367931151687313527782314310395056617474070176176799315072532155545111131n,

--- a/test/bn254.test.ts
+++ b/test/bn254.test.ts
@@ -19,11 +19,13 @@ describe('bn254', () => {
       c0: 18745010300259074081467171901089189864928626882998930881106784720284549917403n,
       c1: 6755404584462298611753346784665337222239198745905936344431516651379215797104n,
     };
-    eql(Fp2.isValid({ c0: 0n, c1: 0n }), true);
+    eql(Fp2.isValid({ c0: 1n, c1: 1n }), true);
     eql(Fp2.isValid(x), true);
     eql(Fp2.isValid(y), true);
-    eql(Fp2.isValid({ c0: Fp.ORDER, c1: 0n }), false);
-    eql(Fp2.isValid({ c0: 0n, c1: Fp.ORDER }), false);
+    eql(Fp2.isValid({ c0: Fp.ORDER - 1n, c1: 1n }), true);
+    eql(Fp2.isValid({ c0: 1n, c1: Fp.ORDER - 1n }), true);
+    eql(Fp2.isValid({ c0: Fp.ORDER, c1: 1n }), false);
+    eql(Fp2.isValid({ c0: 1n, c1: Fp.ORDER }), false);
     const mul = Fp2.mul(x, y);
     eql(mul, {
       c0: 14915367931151687313527782314310395056617474070176176799315072532155545111131n,
@@ -137,6 +139,23 @@ describe('bn254', () => {
         c1: 9533292755262567365755835323107174518472361243562718718917822947506880920117n,
       },
     };
+    eql(Fp6.isValid(x), true);
+    eql(Fp6.isValid(y), true);
+    eql(Fp6.isValid({ ...x, c0: { c0: 1n, c1: 1n } }), true);
+    eql(Fp6.isValid({ ...x, c1: { c0: 1n, c1: 1n } }), true);
+    eql(Fp6.isValid({ ...x, c2: { c0: 1n, c1: 1n } }), true);
+    eql(Fp6.isValid({ ...x, c0: { c0: 1n, c1: Fp.ORDER - 1n } }), true);
+    eql(Fp6.isValid({ ...x, c0: { c0: Fp.ORDER - 1n, c1: 1n } }), true);
+    eql(Fp6.isValid({ ...x, c1: { c0: 1n, c1: Fp.ORDER - 1n } }), true);
+    eql(Fp6.isValid({ ...x, c1: { c0: Fp.ORDER - 1n, c1: 1n } }), true);
+    eql(Fp6.isValid({ ...x, c2: { c0: 1n, c1: Fp.ORDER - 1n } }), true);
+    eql(Fp6.isValid({ ...x, c2: { c0: Fp.ORDER - 1n, c1: 1n } }), true);
+    eql(Fp6.isValid({ ...x, c0: { c0: 1n, c1: Fp.ORDER } }), false);
+    eql(Fp6.isValid({ ...x, c0: { c0: Fp.ORDER, c1: 1n } }), false);
+    eql(Fp6.isValid({ ...x, c1: { c0: 1n, c1: Fp.ORDER } }), false);
+    eql(Fp6.isValid({ ...x, c1: { c0: Fp.ORDER, c1: 1n } }), false);
+    eql(Fp6.isValid({ ...x, c2: { c0: 1n, c1: Fp.ORDER } }), false);
+    eql(Fp6.isValid({ ...x, c2: { c0: Fp.ORDER, c1: 1n } }), false);
     const mul = Fp6.mul(x, y);
     eql(
       mul,
@@ -280,6 +299,8 @@ describe('bn254', () => {
         9227965260032410354414324195411397451806478640651098414622140162144550225774n,
         4565231055964369875954050676600907662092934946529352128407430527253758726453n,
       ]);
+      eql(Fp12.isValid(x), true);
+      eql(Fp12.isValid(y), true);
       const mul = Fp12.mul(x, y);
       eql(
         mul,
@@ -484,6 +505,7 @@ describe('bn254', () => {
         0x1f7797b3b1b3bc1b201b49d1e6d32a3114444f43bcd8cac719fbcef72d861449n,
         0x0aaa7b3a32f45da005612e5f1d642f4c3747672cb6e299260fc8ce90cc5a8a87n,
       ]);
+      eql(Fp12.isValid(mul), true);
       eql(
         Fp12.finalExponentiate(mul),
         Fp12.fromBigTwelve([
@@ -583,6 +605,7 @@ describe('bn254', () => {
         14233000115032918798785952246007985270659932100988995610419881744204174857289n,
         4824342970688691964976119141257507032105805643608313922359860622298332170887n,
       ]);
+      eql(Fp12.isValid(f12m), true);
       const f2 = {
         c0: 14915367931151687313527782314310395056617474070176176799315072532155545111131n,
         c1: 21234748560869198098271980834340238051100753263426135951820710752881888827685n,


### PR DESCRIPTION
1. `Fp2.isValid` was expecting both components to be between `0` and `Fp.ORDER * Fp.ORDER`, when it should have expected them to be between `0` and `Fp.ORDER`
  This unifies `Fp2` code with `Fp6` and `Fp12`.

2. `Fp2.fromBytes` expects both components to fit into separate full bytes, adjust `Fp2.BYTES` calculation to reflect that.
    https://github.com/paulmillr/noble-curves/blob/40ef4654811e451d4cae0ef7db5532874d450d2e/src/abstract/tower.ts#L334-L338
    
    This also unifies `Fp2` code with `Fp6` and `Fp12`.

3. `Fp2.ORDER` is now unused, at least in `tower.ts`
 
This expects `Fp.BITS`, `Fp.BYTES`, `Fp.isValid` to be present

Also, this does not fix the discrepancy between `.ORDER`:
 1. `Fp.ORDER` is `Fp` field order
 2. `Fp2.ORDER` is `{ Fp, Fp }` quadratic field order
 3. `Fp6.ORDER` is `{ Fp, Fp }` quadratic field order
 4. `Fp12.ORDER` is `{ Fp, Fp }` quadratic field order

2-4 are not really used and make little sense (and are likely a source of bugs), but this PR does not remove them