### PR TITLE
ed448: use 57-byte Fp/Fn container for E448

### DIFF
--- a/src/ed448.ts
+++ b/src/ed448.ts
@@ -240,7 +240,7 @@ export const ed448ph: EdDSA = /* @__PURE__ */ ed4({ prehash: shake256_64 });
  * const point = E448.BASE.multiply(2n);
  * ```
  */
-export const E448: EdwardsPointCons = /* @__PURE__ */ edwards(E448_CURVE);
+export const E448: EdwardsPointCons = /* @__PURE__ */ edwards(E448_CURVE, { Fp, Fn });
 
 /**
  * ECDH using curve448 aka x448.

--- a/test/ed448.test.ts
+++ b/test/ed448.test.ts
@@ -8,7 +8,7 @@ import { shake256 } from '@noble/hashes/sha3.js';
 import * as fc from 'fast-check';
 import { describe, should } from '@paulmillr/jsbt/test.js';
 import { deepStrictEqual as eql, throws } from 'node:assert';
-import { ed448, ed448ph, x448 } from '../src/ed448.ts';
+import { E448, ed448, ed448ph, x448 } from '../src/ed448.ts';
 import { asciiToBytes, bytesToNumberLE, numberToBytesLE } from '../src/utils.ts';
 import { json } from './utils.ts';
 
@@ -540,6 +540,17 @@ describe('ed448', () => {
       // const u = Fp.create(y * y * invX);
       eql(numberToBytesLE(u, 56), x448.GuBytes);
     });
+  });
+
+  should('E448: encode/decode round-trip for y >= 2^447', () => {
+    // 2*BASE on E448 has y in [2^447, p), where the x-sign bit must live in a
+    // 57-byte container. A 56-byte container would clobber bit 447 of y.
+    const P = E448.BASE.add(E448.BASE).add(E448.BASE);
+    const encoded = P.toBytes();
+    eql(encoded.length, 57);
+    const Q = E448.fromBytes(encoded);
+    eql(Q.x, P.x);
+    eql(Q.y, P.y);
   });
 });
 


### PR DESCRIPTION
The default Field(p) for E448 had BYTES=56, so the Edwards toBytes implementation wrote the x-sign bit into bit 447 of y, clobbering the high bit for y in [2^447, p). fromBytes symmetrically cleared it, so roundtripping any such point produced a different (or off-curve) point. The base point has Gy < 2^447, masking the bug in most code paths. Pass the 456-bit Fp/Fn already defined for ed448_Point so E448 uses the same 57-byte container, matching the toBytes/fromBytes sign layout.