### PR TITLE
bls: verifyBatch validates message brand

### DIFF
--- a/src/abstract/bls.ts
+++ b/src/abstract/bls.ts
@@ -670,7 +670,7 @@ function createBlsSig<P, S>(
     ): boolean {
       aNonEmpty(items);
       const sig = normSig(signature);
-      const nMessages = items.map((i) => i.message);
+      const nMessages = items.map((i) => amsg(i.message));
       const nPublicKeys = items.map((i) => normPub(i.publicKey));
       // NOTE: this works only for exact same object
       const messagePubKeyMap = new Map<SigPoint, PubPoint[]>();

--- a/test/bls12-381.test.ts
+++ b/test/bls12-381.test.ts
@@ -1260,6 +1260,15 @@ describe('bls12-381 verify', () => {
         )
       );
     });
+    should('throws on non-hashed message (raw bytes)', () => {
+      const [priv, msgBytes] = G2_VECTORS[0];
+      const msg = blsl.hash(msgBytes);
+      const sig = blsl.sign(msg, priv);
+      const pub = getPubKey(priv);
+      // passing raw bytes instead of a hashed SigPoint must throw, not silently return false
+      const items = [{ message: msgBytes as any, publicKey: pub }];
+      throws(() => blsl.verifyBatch(sig, items), /expected valid message hashed/);
+    });
     should('verify multi-signature as simple signature', () => {
       fc.assert(
         // @ts-ignore


### PR DESCRIPTION
verifyBatch passed items[i].message straight into pair/pairingBatch without the amsg() brand check, so passing raw bytes (or any non SigPoint) would throw deep inside pairing, get swallowed by the try/catch and silently return false. The single-message verify already raises an explicit "expected valid message hashed to G2/G1 curve" error; verifyBatch now does the same.