### PR TITLE
montgomery: fix X25519/X448 scalar upper bound precedence

### DIFF
--- a/src/abstract/montgomery.ts
+++ b/src/abstract/montgomery.ts
@@ -150,8 +150,8 @@ export function montgomery(curveDef: TArg<MontgomeryOpts>): TRet<MontgomeryECDH>
   // x448: "2^447 plus four times a value between 0 and 2^445 - 1 (inclusive)"
   const minScalar = is25519 ? _2n ** BigInt(254) : _2n ** BigInt(447);
   const maxAdded = is25519
-    ? BigInt(8) * _2n ** BigInt(251) - _1n
-    : BigInt(4) * _2n ** BigInt(445) - _1n;
+    ? BigInt(8) * (_2n ** BigInt(251) - _1n)
+    : BigInt(4) * (_2n ** BigInt(445) - _1n);
   const maxScalar = minScalar + maxAdded + _1n; // (inclusive)
   const modP = (n: bigint) => mod(n, P);
   const GuBytes = encodeU(Gu);

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -23,6 +23,24 @@ describe('edge cases', () => {
     throws(() => secp256k1.getPublicKey(123n));
     throws(() => secp256k1.sign(Uint8Array.of(), 123n));
   });
+
+  should('x25519 scalar range rejects unclamped scalars above 8*(2^251-1)+2^254', () => {
+    // RFC 7748: valid X25519 scalars are 2^254 + 8*k with k in [0, 2^251 - 1].
+    // So the largest valid scalar is 2^254 + 8*(2^251 - 1) = 2^255 - 8.
+    // Scalars 2^255 - 7 .. 2^255 - 1 must be rejected by the defense-in-depth range
+    // check when a (hypothetical) buggy adjustScalarBytes returns them unclamped.
+    const P = 2n ** 255n - 19n;
+    const passthrough = montgomery({
+      P,
+      type: 'x25519',
+      adjustScalarBytes: (bytes: Uint8Array) => bytes,
+      powPminus2: (x: bigint) => x,
+    });
+    // 2^255 - 1 encoded little-endian as 32 bytes: 31 * 0xff, then 0x7f.
+    const scalar = new Uint8Array(32).fill(0xff);
+    scalar[31] = 0x7f;
+    throws(() => passthrough.getPublicKey(scalar), /scalar/);
+  });
 });
 
 describe('createCurve', () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -24,7 +24,7 @@ describe('edge cases', () => {
     throws(() => secp256k1.sign(Uint8Array.of(), 123n));
   });
 
-  should('x25519 integer range rejects unclamped scalars above 8*(2^251-1)+2^254', () => {
+  should('x25519 integer range rejects unclamped values above 8*(2^251-1)+2^254', () => {
     // RFC 7748: "the resulting integer is of the form 2^254 plus eight times a value
     // between 0 and 2^251 - 1 (inclusive)."
     // Integers 2^255 - 7 .. 2^255 - 1 must be rejected by the defense-in-depth range

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -24,10 +24,10 @@ describe('edge cases', () => {
     throws(() => secp256k1.sign(Uint8Array.of(), 123n));
   });
 
-  should('x25519 scalar range rejects unclamped scalars above 8*(2^251-1)+2^254', () => {
-    // RFC 7748: valid X25519 scalars are 2^254 + 8*k with k in [0, 2^251 - 1].
-    // So the largest valid scalar is 2^254 + 8*(2^251 - 1) = 2^255 - 8.
-    // Scalars 2^255 - 7 .. 2^255 - 1 must be rejected by the defense-in-depth range
+  should('x25519 integer range rejects unclamped scalars above 8*(2^251-1)+2^254', () => {
+    // RFC 7748: "the resulting integer is of the form 2^254 plus eight times a value
+    // between 0 and 2^251 - 1 (inclusive)."
+    // Integers 2^255 - 7 .. 2^255 - 1 must be rejected by the defense-in-depth range
     // check when a (hypothetical) buggy adjustScalarBytes returns them unclamped.
     const P = 2n ** 255n - 19n;
     const passthrough = montgomery({


### PR DESCRIPTION
The maxAdded bounds in abstract/montgomery used `BigInt(8) * _2n ** BigInt(251) - _1n` which, per JS operator precedence, evaluates to `2^254 - 1` rather than the RFC 7748 value `8 * (2^251 - 1) = 2^254 - 8`. The same mistake exists for X448 (`4 * 2^445 - 1` instead of `4 * (2^445 - 1)`).

The resulting loose maxScalar admitted 7 values (X25519) / 3 values (X448) above the RFC range. adjustScalarBytes is the authoritative clamper so no properly-clamped scalar is affected, but the defense-in-depth aInRange check is now tight. Added a regression test using a passthrough adjustScalarBytes.