### PR TITLE
hash-to-curve: apply default DST when partial options are passed

### DIFF
--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -611,8 +611,10 @@ export const ristretto255_hasher: H2CHasherBase<typeof _RistrettoPoint> = Object
     // It is not: it is the older hash-to-curve construction.
     return ristretto255_hasher.deriveToCurve!(xmd);
   },
-  hashToScalar(msg: TArg<Uint8Array>, options: TArg<H2CDSTOpts> = { DST: _DST_scalar }) {
-    const xmd = expand_message_xmd(msg, options.DST, 64, sha512);
+  hashToScalar(msg: TArg<Uint8Array>, options?: TArg<H2CDSTOpts>) {
+    // Apply default only when DST is missing, so partial option objects still get it.
+    const DST = options?.DST === undefined ? _DST_scalar : options.DST;
+    const xmd = expand_message_xmd(msg, DST, 64, sha512);
     return Fn.create(bytesToNumberLE(xmd));
   },
   /**

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -612,7 +612,6 @@ export const ristretto255_hasher: H2CHasherBase<typeof _RistrettoPoint> = Object
     return ristretto255_hasher.deriveToCurve!(xmd);
   },
   hashToScalar(msg: TArg<Uint8Array>, options?: TArg<H2CDSTOpts>) {
-    // Apply default only when DST is missing, so partial option objects still get it.
     const DST = options?.DST === undefined ? _DST_scalar : options.DST;
     const xmd = expand_message_xmd(msg, DST, 64, sha512);
     return Fn.create(bytesToNumberLE(xmd));

--- a/src/ed448.ts
+++ b/src/ed448.ts
@@ -624,9 +624,11 @@ export const decaf448_hasher: H2CHasherBase<typeof _DecafPoint> = Object.freeze(
    * RFC is invalid. RFC says "use 64-byte xof", while for 2^-112 bias
    * it must use 84-byte xof (56+56/2), not 64.
    */
-  hashToScalar(msg: TArg<Uint8Array>, options: TArg<H2CDSTOpts> = { DST: _DST_scalar }): bigint {
+  hashToScalar(msg: TArg<Uint8Array>, options?: TArg<H2CDSTOpts>): bigint {
+    // Apply default only when DST is missing, so partial option objects still get it.
+    const DST = options?.DST === undefined ? _DST_scalar : options.DST;
     // Can't use `Fn448.fromBytes()`. 64-byte input => 56-byte field element
-    const xof = expand_message_xof(msg, options.DST, 64, 256, shake256);
+    const xof = expand_message_xof(msg, DST, 64, 256, shake256);
     return Fn448.create(bytesToNumberLE(xof));
   },
   /**

--- a/src/ed448.ts
+++ b/src/ed448.ts
@@ -625,7 +625,6 @@ export const decaf448_hasher: H2CHasherBase<typeof _DecafPoint> = Object.freeze(
    * it must use 84-byte xof (56+56/2), not 64.
    */
   hashToScalar(msg: TArg<Uint8Array>, options?: TArg<H2CDSTOpts>): bigint {
-    // Apply default only when DST is missing, so partial option objects still get it.
     const DST = options?.DST === undefined ? _DST_scalar : options.DST;
     // Can't use `Fn448.fromBytes()`. 64-byte input => 56-byte field element
     const xof = expand_message_xof(msg, DST, 64, 256, shake256);

--- a/test/rfc9496-ristretto-decaf.test.ts
+++ b/test/rfc9496-ristretto-decaf.test.ts
@@ -211,6 +211,11 @@ describe('ristretto255', () => {
       'be2194e53cc014665821003f8ecf49e99b7cd16f5326e53f234ecd21c448ee6c'
     );
   });
+  should('ristretto255_hasher.hashToScalar applies default DST for partial options', () => {
+    const msg = new Uint8Array(10).fill(5);
+    const expected = ristretto255_hasher.hashToScalar(msg);
+    eql(ristretto255_hasher.hashToScalar(msg, {}), expected);
+  });
   should('wrapper helpers keep canonical abstract-group behavior', () => {
     const p = RistrettoPoint.BASE.multiply(5n);
     const affine = p.toAffine();


### PR DESCRIPTION
The hashToScalar methods on ristretto255_hasher and decaf448_hasher used a destructured default `options = { DST: _DST_scalar }` which only triggers when the argument is strictly undefined. Passing any partial object (e.g. `{}`) forwarded `options.DST === undefined` into expand_message_xmd/xof, which then threw "DST must be Uint8Array or ascii string".

Switch to the `options?.DST === undefined ? default : options.DST` pattern already used by the sibling hashToCurve so the default DST is applied per-field.