### PR TITLE
Reject non-canonical BLS signature encodings

### DIFF
--- a/src/abstract/bls.ts
+++ b/src/abstract/bls.ts
@@ -735,13 +735,14 @@ function createBlsSig<P, S>(
       toHex: notImplemented,
     };
   }
+  const sigCoder = SignatureCoder;
   type PubPoint = WeierstrassPoint<P>;
   type SigPoint = WeierstrassPoint<S>;
   function normPub(point: PubPoint | BLSInput): PubPoint {
     return point instanceof PubPoint ? (point as PubPoint) : PubPoint.fromBytes(point);
   }
   function normSig(point: SigPoint | BLSInput): SigPoint {
-    return point instanceof SigPoint ? (point as SigPoint) : SigPoint.fromBytes(point);
+    return point instanceof SigPoint ? (point as SigPoint) : sigCoder.fromBytes(point);
   }
   // Sign/verify here take points already hashed onto the signature subgroup.
   // Raw bytes and points from the other subgroup must fail this constructor-brand
@@ -874,7 +875,7 @@ function createBlsSig<P, S>(
       const opts = DST === undefined ? undefined : { DST };
       return hashToSigCurve(messageBytes, opts);
     },
-    Signature: Object.freeze({ ...SignatureCoder }),
+    Signature: Object.freeze({ ...sigCoder }),
   }) /*satisfies Signer */;
 }
 

--- a/src/bls12-381.ts
+++ b/src/bls12-381.ts
@@ -83,7 +83,6 @@ import { Field, type IField } from './abstract/modular.ts';
 import {
   abytes,
   bitLen,
-  bitMask,
   bytesToHex,
   bytesToNumberBE,
   concatBytes,
@@ -363,12 +362,17 @@ const fp2 = {
   decode(bytes: TArg<Uint8Array>) {
     const { BYTES: L } = Fp;
     return Fp2.create({
-      c0: Fp.create(bytesToNumberBE(bytes.subarray(L))),
-      c1: Fp.create(bytesToNumberBE(bytes.subarray(0, L))),
+      c0: decodeFp(bytes.subarray(L)),
+      c1: decodeFp(bytes.subarray(0, L)),
     });
   },
 };
 const BaseFp = Fp;
+function decodeFp(bytes: TArg<Uint8Array>): Fp {
+  const num = bytesToNumberBE(bytes);
+  if (num >= Fp.ORDER) throw new Error('invalid BLS12-381 field element');
+  return Fp.create(num);
+}
 type Mask = { compressed: boolean; infinity: boolean; sort: boolean };
 // Keep BLS12-381 point/signature codecs on one control-flow skeleton: the G1/G2
 // and point/signature variants differ only in field packing, subgroup bytes, and
@@ -406,8 +410,8 @@ const coder = <T>(
       const len = compressed ? W : 2 * W;
       if (value.length !== len) throw new Error(`invalid ${name} point: expected ${len} bytes`);
       if (infinity) {
-        // Infinity canonicality has to be checked on raw bytes before decode()
-        // reduces coordinates modulo p and turns non-empty payloads into zero.
+        // Infinity has a dedicated encoding: after the flag bits are cleared, every
+        // remaining payload byte must be zero.
         for (const b of value) {
           if (b) throw new Error(`invalid ${name} point: non-canonical zero`);
         }
@@ -422,8 +426,8 @@ const coder = <T>(
       } else {
         y = dec(value.subarray(W));
       }
-      // Noble keeps the permissive coordinate reduction path here, but an
-      // omitted infinity flag must not still decode to ZERO afterwards.
+      // The all-zero uncompressed payload must use the infinity flag instead of
+      // decoding as an ordinary affine point.
       if (!compressed && F.is0(x) && F.is0(y))
         throw new Error(`invalid ${name} point: uncompressed`);
       return { x, y };
@@ -444,7 +448,6 @@ function validateMask({ compressed, infinity, sort }: Mask) {
 }
 function parseMask(bytes: TArg<Uint8Array>) {
   // Copy, so we can remove mask data.
-  // It will be removed also later, when Fp.create will call modulo.
   bytes = copyBytes(bytes);
   const mask = bytes[0] & 0b1110_0000;
   const compressed = !!((mask >> 7) & 1); // compression bit (0b1000_0000)
@@ -472,7 +475,7 @@ const g1coder = coder(
   Fp,
   Fp.create(bls12_381_CURVE_G1.b),
   (x: Fp) => numberToBytesBE(x, Fp.BYTES),
-  (bytes: TArg<Uint8Array>) => Fp.create(bytesToNumberBE(bytes) & bitMask(Fp.BITS)),
+  decodeFp,
   (y: Fp) => [y]
 );
 const g1 = { point: g1coder(true), sig: g1coder(false) };

--- a/test/bls12-381.test.ts
+++ b/test/bls12-381.test.ts
@@ -1086,6 +1086,24 @@ describe('bls12-381 verify', () => {
         eql(resHex, false);
       }
     });
+    should('rejects uncompressed signature bytes in raw-byte APIs', () => {
+      const secretKey = privKeyNumToBytes(42n);
+      const msg = blsl.hash(asciiToBytes('long signature codec'));
+      const sig = blsl.sign(msg, secretKey);
+      const pub = blsl.getPublicKey(secretKey);
+      const sigBytes = blsl.Signature.toBytes(sig);
+      const sigUncompressed = sig.toBytes(false);
+      const pubUncompressed = pub.toBytes(false);
+
+      eql(blsl.verify(sig, msg, pub), true);
+      eql(blsl.verify(sigBytes, msg, pubUncompressed), true);
+      throws(() => blsl.verify(sigUncompressed, msg, pub), /signature|point|bytes/);
+      throws(
+        () => blsl.verifyBatch(sigUncompressed, [{ message: msg, publicKey: pub }]),
+        /signature|point|bytes/
+      );
+      throws(() => blsl.aggregateSignatures([sigUncompressed]), /signature|point|bytes/);
+    });
   });
   describe('shortSignatures', () => {
     should('sign, verify, and negative cases', () => {
@@ -1132,6 +1150,24 @@ describe('bls12-381 verify', () => {
         const resHex = blss.verify(sig, msg, invPub);
         eql(resHex, false);
       }
+    });
+    should('rejects uncompressed signature bytes in raw-byte APIs', () => {
+      const secretKey = privKeyNumToBytes(42n);
+      const msg = blss.hash(asciiToBytes('short signature codec'));
+      const sig = blss.sign(msg, secretKey);
+      const pub = blss.getPublicKey(secretKey);
+      const sigBytes = blss.Signature.toBytes(sig);
+      const sigUncompressed = sig.toBytes(false);
+      const pubUncompressed = pub.toBytes(false);
+
+      eql(blss.verify(sig, msg, pub), true);
+      eql(blss.verify(sigBytes, msg, pubUncompressed), true);
+      throws(() => blss.verify(sigUncompressed, msg, pub), /signature|point|bytes/);
+      throws(
+        () => blss.verifyBatch(sigUncompressed, [{ message: msg, publicKey: pub }]),
+        /signature|point|bytes/
+      );
+      throws(() => blss.aggregateSignatures([sigUncompressed]), /signature|point|bytes/);
     });
   });
   should('verify augmented signature', () => {
@@ -1701,6 +1737,50 @@ describe('bls12-381 deterministic', () => {
 });
 
 describe('BLS flag edge cases', () => {
+  should('reject non-canonical field limbs in point and signature encodings', () => {
+    const { Fp } = bls12_381.fields;
+    const p = Fp.ORDER;
+    const L = Fp.BYTES;
+    const pBytes = utils.numberToBytesBE(p, L);
+    const withLimb = (len: number, offset: number, flags = 0) => {
+      const out = new Uint8Array(len);
+      out.set(pBytes, offset);
+      out[0] |= flags;
+      return out;
+    };
+
+    const g1CompressedP = withLimb(L, 0, 0x80);
+    throws(() => bls12_381.G1.Point.fromBytes(g1CompressedP));
+    throws(() => bls12_381.shortSignatures.Signature.fromBytes(g1CompressedP));
+
+    for (const offset of [0, L]) {
+      throws(() => bls12_381.G1.Point.fromBytes(withLimb(2 * L, offset)));
+    }
+
+    for (const offset of [0, L]) {
+      const g2CompressedP = withLimb(2 * L, offset, 0x80);
+      throws(() => bls12_381.G2.Point.fromBytes(g2CompressedP));
+      throws(() => bls12_381.longSignatures.Signature.fromBytes(g2CompressedP));
+    }
+
+    for (const offset of [0, L, 2 * L, 3 * L]) {
+      throws(() => bls12_381.G2.Point.fromBytes(withLimb(4 * L, offset)));
+    }
+  });
+
+  should('reject non-flag high bits in uncompressed coordinate limbs', () => {
+    const L = bls12_381.fields.Fp.BYTES;
+    const g1 = bls12_381.G1.Point.BASE.toBytes(false);
+    g1[L] |= 0x20;
+    throws(() => bls12_381.G1.Point.fromBytes(g1));
+
+    for (const offset of [L, 2 * L, 3 * L]) {
+      const g2 = bls12_381.G2.Point.BASE.toBytes(false);
+      g2[offset] |= 0x20;
+      throws(() => bls12_381.G2.Point.fromBytes(g2));
+    }
+  });
+
   should('reject uncompressed points that decode to infinity without the infinity flag', () => {
     const { Fp } = bls12_381.fields;
     const p = Fp.ORDER;


### PR DESCRIPTION
## Summary
- reject non-canonical BLS12-381 field limbs before constructing field elements
- parse raw BLS signature bytes through the mode-specific `Signature` codec
- add regression tests for modularly equivalent encodings and uncompressed signature encodings

Fixes https://github.com/paulmillr/noble-curves/issues/242
Fixes https://github.com/paulmillr/noble-curves/issues/243

## Tests
- `npm run build`
- `node --no-warnings test/bls12-381.test.ts`
