### PR TITLE
Bind recovered ECDSA signatures to recovery id

### DIFF
--- a/src/abstract/weierstrass.ts
+++ b/src/abstract/weierstrass.ts
@@ -1580,6 +1580,7 @@ export function ecdsa(
       const sig = Signature.fromBytes(signature, format);
       const P = Point.fromBytes(publicKey);
       if (lowS && sig.hasHighS()) return false;
+      if (format === 'recovered' && !sig.recoverPublicKey(message).equals(P)) return false;
       const { r, s } = sig;
       const h = bits2int_modN(message); // mod n, not mod p
       const is = Fn.inv(s); // s^-1 mod n

--- a/test/ecdsa.test.ts
+++ b/test/ecdsa.test.ts
@@ -132,6 +132,23 @@ describe('ECDSA', () => {
       });
     });
   }
+
+  should('verify() binds recovered signatures to their recovery id', () => {
+    const msg = Uint8Array.from({ length: 32 }, (_, i) => i);
+    const secretKey = Uint8Array.from({ length: 32 }, (_, i) => i + 1);
+    const publicKey = p256.getPublicKey(secretKey);
+    const sig = p256.sign(msg, secretKey, { prehash: false, format: 'recovered' });
+    const compact = sig.slice(1);
+    const der = p256.Signature.fromBytes(sig, 'recovered').toBytes('der');
+
+    eql(p256.verify(sig, msg, publicKey, { prehash: false, format: 'recovered' }), true);
+    eql(p256.verify(compact, msg, publicKey, { prehash: false, format: 'compact' }), true);
+    eql(p256.verify(der, msg, publicKey, { prehash: false, format: 'der' }), true);
+
+    const wrongRecovery = sig.slice();
+    wrongRecovery[0] ^= 1;
+    eql(p256.verify(wrongRecovery, msg, publicKey, { prehash: false, format: 'recovered' }), false);
+  });
 });
 
 describe('weierstrass ECDH', () => {


### PR DESCRIPTION
## Summary
- bind recovered-format ECDSA verification to the recovery byte
- reject recovered signatures whose recovered public key does not match the caller-provided public key
- add a regression test for recovery-byte malleability

Fixes https://github.com/paulmillr/noble-curves/issues/246

## Tests
- `node --no-warnings test/ecdsa.test.ts`
