### PR TITLE
Fix Edwards-to-Montgomery conversion helpers

### DIFF
--- a/src/abstract/edwards.ts
+++ b/src/abstract/edwards.ts
@@ -142,6 +142,10 @@ export type EdDSAOpts = Partial<{
   domain: (data: TArg<Uint8Array>, ctx: TArg<Uint8Array>, phflag: boolean) => TRet<Uint8Array>;
   /** Optional hash-to-curve mapper for protocols like Ristretto hash-to-group. */
   mapToCurve: (scalar: bigint[]) => AffinePoint<bigint>;
+  /** Optional conversion from this Edwards curve to a birational/isogenous Montgomery curve. */
+  toMontgomery: (point: EdwardsPoint) => TRet<Uint8Array>;
+  /** Optional secret-key conversion for the same Montgomery curve as `toMontgomery`. */
+  toMontgomerySecret: (secretKey: TArg<Uint8Array>) => TRet<Uint8Array>;
   /** Optional prehash function used before signing or verifying messages. */
   prehash: FHash;
   /** Default verification decoding policy. ZIP-215 is more permissive than RFC 8032 / NIST. */
@@ -213,6 +217,7 @@ export interface EdDSA {
 
     /**
      * Converts ed public key to x public key.
+     * Throws when the Edwards curve has no supported Montgomery conversion.
      *
      * There is NO `fromMontgomery`:
      * - There are 2 valid ed25519 points for every x25519, with flipped coordinate
@@ -232,6 +237,7 @@ export interface EdDSA {
     toMontgomery: (publicKey: TArg<Uint8Array>) => TRet<Uint8Array>;
     /**
      * Converts ed secret key to x secret key.
+     * Throws when the Edwards curve has no supported Montgomery conversion.
      * @example
      * Converts ed secret key to x secret key.
      *
@@ -811,6 +817,8 @@ export function eddsa(
       prehash: 'function',
       zip215: 'boolean',
       mapToCurve: 'function',
+      toMontgomery: 'function',
+      toMontgomerySecret: 'function',
     }
   );
 
@@ -827,6 +835,8 @@ export function eddsa(
   }
 
   const randomBytes = opts.randomBytes === undefined ? wcRandomBytes : opts.randomBytes;
+  const toMontgomery = opts.toMontgomery;
+  const toMontgomerySecret = opts.toMontgomerySecret;
   const adjustScalarBytes =
     opts.adjustScalarBytes === undefined
       ? (bytes: TArg<Uint8Array>) => bytes as TRet<Uint8Array>
@@ -995,28 +1005,16 @@ export function eddsa(
     randomSecretKey,
     isValidSecretKey,
     isValidPublicKey,
-    /**
-     * Converts ed public key to x public key. Uses formula:
-     * - ed25519:
-     *   - `(u, v) = ((1+y)/(1-y), sqrt(-486664)*u/x)`
-     *   - `(x, y) = (sqrt(-486664)*u/v, (u-1)/(u+1))`
-     * - ed448:
-     *   - `(u, v) = ((y-1)/(y+1), sqrt(156324)*u/x)`
-     *   - `(x, y) = (sqrt(156324)*u/v, (1+u)/(1-u))`
-     */
+    /** Converts an Edwards public key to a companion Montgomery public key. */
     toMontgomery(publicKey: TArg<Uint8Array>): TRet<Uint8Array> {
-      const { y } = Point.fromBytes(publicKey);
-      const size = lengths.publicKey;
-      const is25519 = size === 32;
-      if (!is25519 && size !== 57) throw new Error('only defined for 25519 and 448');
-      const u = is25519 ? Fp.div(_1n + y, _1n - y) : Fp.div(y - _1n, y + _1n);
-      return Fp.toBytes(u) as TRet<Uint8Array>;
+      if (toMontgomery === undefined)
+        throw new Error('Montgomery conversion is not supported for this curve');
+      return toMontgomery(Point.fromBytes(publicKey));
     },
     toMontgomerySecret(secretKey: TArg<Uint8Array>): TRet<Uint8Array> {
-      const size = lengths.secretKey;
-      abytes(secretKey, size);
-      const hashed = hash(secretKey.subarray(0, size));
-      return adjustScalarBytes(hashed).subarray(0, size) as TRet<Uint8Array>;
+      if (toMontgomerySecret === undefined)
+        throw new Error('Montgomery conversion is not supported for this curve');
+      return toMontgomerySecret(secretKey);
     },
   };
   Object.freeze(lengths);

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -124,6 +124,23 @@ const ed25519_Point = /* @__PURE__ */ edwards(ed25519_CURVE, { uvRatio });
 // Public field alias stays stricter than the RFC 8032 Appendix A sample code:
 // `Fp.inv(0)` throws instead of returning `0`.
 const Fp = /* @__PURE__ */ (() => ed25519_Point.Fp)();
+
+function toMontgomery(point: EdwardsPoint): TRet<Uint8Array> {
+  // Birational map from Ed25519 to Curve25519 / X25519:
+  //   (u, v) = ((1 + y) / (1 - y), sqrt(-486664) * u / x)
+  //   (x, y) = (sqrt(-486664) * u / v, (u - 1) / (u + 1))
+  const { y } = point;
+  return Fp.toBytes(Fp.div(_1n + y, _1n - y)) as TRet<Uint8Array>;
+}
+
+function toMontgomerySecret(secretKey: TArg<Uint8Array>): TRet<Uint8Array> {
+  const size = ed25519_Point.Fp.BYTES;
+  abytes(secretKey, size);
+  return adjustScalarBytes(sha512(secretKey.subarray(0, size))).subarray(
+    0,
+    size
+  ) as TRet<Uint8Array>;
+}
 const Fn = /* @__PURE__ */ (() => ed25519_Point.Fn)();
 
 // RFC 8032 `dom2` helper for ctx/ph variants only. Plain Ed25519 keeps the
@@ -147,7 +164,10 @@ function ed(opts: TArg<EdDSAOpts>) {
   return eddsa(
     ed25519_Point,
     sha512,
-    Object.assign({ adjustScalarBytes, zip215: true }, opts as EdDSAOpts)
+    Object.assign(
+      { adjustScalarBytes, toMontgomery, toMontgomerySecret, zip215: true },
+      opts as EdDSAOpts
+    )
   );
 }
 

--- a/src/ed448.ts
+++ b/src/ed448.ts
@@ -168,6 +168,25 @@ const Fp448 = /* @__PURE__ */ (() => Field(ed448_CURVE_p, { BITS: 448, isLE: tru
 // Strict 56-byte scalar parser matching RFC 9496's recommended canonical form.
 const Fn448 = /* @__PURE__ */ (() => Field(ed448_CURVE.n, { BITS: 448, isLE: true }))();
 
+function toMontgomery(point: EdwardsPoint): TRet<Uint8Array> {
+  // RFC 7748 section 4.2 maps Ed448-Goldilocks to Curve448 via a 4-isogeny.
+  // The u-coordinate map is:
+  //   u = y^2 / x^2
+  // In projective coordinates this is:
+  //   u = Y^2 / X^2
+  const u = Fp.div(Fp.mul(point.Y, point.Y), Fp.mul(point.X, point.X));
+  return Fp448.toBytes(u) as TRet<Uint8Array>;
+}
+
+function toMontgomerySecret(secretKey: TArg<Uint8Array>): TRet<Uint8Array> {
+  const size = ed448_Point.Fp.BYTES;
+  abytes(secretKey, size);
+  return adjustScalarBytes(shake256_114(secretKey.subarray(0, size))).subarray(
+    0,
+    56
+  ) as TRet<Uint8Array>;
+}
+
 // SHAKE256(dom4(phflag,context)||x, 114)
 // RFC 8032 `dom4` prefix. Empty contexts are valid; the accepted length range
 // is 0..255 octets inclusive.
@@ -188,7 +207,10 @@ function ed4(opts: TArg<EdDSAOpts>) {
   return eddsa(
     ed448_Point,
     shake256_114,
-    Object.assign({ adjustScalarBytes, domain: dom4 }, opts as EdDSAOpts)
+    Object.assign(
+      { adjustScalarBytes, domain: dom4, toMontgomery, toMontgomerySecret },
+      opts as EdDSAOpts
+    )
   );
 }
 

--- a/test/ed.test.ts
+++ b/test/ed.test.ts
@@ -2,7 +2,7 @@ import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { describe, should } from '@paulmillr/jsbt/test.js';
 import { deepStrictEqual as eql } from 'node:assert';
 import { ed25519, ed25519ctx, ed25519ph, x25519 } from '../src/ed25519.ts';
-import { ed448 } from '../src/ed448.ts';
+import { ed448, x448 } from '../src/ed448.ts';
 import { numberToBytesLE } from '../src/utils.ts';
 import { deepHexToBytes, json } from './utils.ts';
 
@@ -144,7 +144,7 @@ describe('X25519 RFC7748 ECDH', () => {
   });
 
   describe('toMontgomery()', () => {
-    should('edwardsToMontgomery outputs, keyPair, and ECDH', () => {
+    should('ed25519 toMontgomery outputs, keyPair, and ECDH', () => {
       const edSecret = hexToBytes(
         '77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a'
       );
@@ -174,15 +174,43 @@ describe('X25519 RFC7748 ECDH', () => {
           ed25519.utils.toMontgomery(edPublic1)
         )
       );
+    });
 
-      const ed448Secret = hexToBytes(
+    should('ed448 toMontgomery outputs, keyPair, and ECDH', () => {
+      const edSecret = hexToBytes(
         '77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab1'
       );
-      const ed448Public = ed448.getPublicKey(ed448Secret);
-      const ed448XPublic = ed448.utils.toMontgomery(ed448Public);
+      const edPublic = ed448.getPublicKey(edSecret);
+      const xPrivate = ed448.utils.toMontgomerySecret(edSecret);
       eql(
-        bytesToHex(ed448XPublic),
-        'f0301c19656bce1d1cd0a474c952d196041811b63617fc8fdaacee533644e2b2d49273426c8dbb5a76033ea84fb5215b84f9ebf22bde0b0700'
+        bytesToHex(xPrivate),
+        'b891484436bde1596114f68f5911a7c1c08908c4150724e7a4b9efe5c9dc7ed97a19a10319f2ac14bed4087c688d66b51d3f4f281bd362a9'
+      );
+      const xPublic = ed448.utils.toMontgomery(edPublic);
+      eql(
+        bytesToHex(xPublic),
+        '8b596ceacda13c99a4c968f6feac6c101f4eb1e7d6c45192f029ee7725e3a10bc64b123322e0f7b4e9edeaa70e05e297311171ee73f550a0'
+      );
+
+      const randomEdSecret = ed448.utils.randomSecretKey();
+      const randomEdPublic = ed448.getPublicKey(randomEdSecret);
+      const xSecret = ed448.utils.toMontgomerySecret(randomEdSecret);
+      const expectedXPublic = x448.getPublicKey(xSecret);
+      eql(ed448.utils.toMontgomery(randomEdPublic), expectedXPublic);
+
+      const edSecret1 = ed448.utils.randomSecretKey();
+      const edPublic1 = ed448.getPublicKey(edSecret1);
+      const edSecret2 = ed448.utils.randomSecretKey();
+      const edPublic2 = ed448.getPublicKey(edSecret2);
+      eql(
+        x448.getSharedSecret(
+          ed448.utils.toMontgomerySecret(edSecret1),
+          ed448.utils.toMontgomery(edPublic2)
+        ),
+        x448.getSharedSecret(
+          ed448.utils.toMontgomerySecret(edSecret2),
+          ed448.utils.toMontgomery(edPublic1)
+        )
       );
     });
   });

--- a/test/misc.test.ts
+++ b/test/misc.test.ts
@@ -20,6 +20,12 @@ const G_PROOF = new Point(
 const getXY = (p) => ({ x: p.x, y: p.y });
 
 describe('jubjub', () => {
+  should('rejects unsupported Montgomery conversion', () => {
+    const secret = new Uint8Array(32).fill(1);
+    throws(() => jubjub.utils.toMontgomery(jubjub.getPublicKey(secret)), /not supported/);
+    throws(() => jubjub.utils.toMontgomerySecret(secret), /not supported/);
+  });
+
   should('toBytes/fromBytes', () => {
     // More than field
     throws(() =>
@@ -85,6 +91,12 @@ describe('jubjub', () => {
 });
 
 describe('babyjubjub', () => {
+  should('rejects unsupported Montgomery conversion', () => {
+    const secret = new Uint8Array(32).fill(1);
+    throws(() => babyjubjub.utils.toMontgomery(babyjubjub.getPublicKey(secret)), /not supported/);
+    throws(() => babyjubjub.utils.toMontgomerySecret(secret), /not supported/);
+  });
+
   should('signing, hash validation, and base point', () => {
     const seed = new Uint8Array(32).fill(9);
     const msg = new Uint8Array([1, 2, 3]);


### PR DESCRIPTION
## Summary
- gate Edwards-to-Montgomery helpers behind explicit curve support
- reject unsupported Jubjub and BabyJubJub conversions instead of treating 32-byte keys as Ed25519
- use Ed448/X448-specific conversion hooks and add focused regression tests

Fixes https://github.com/paulmillr/noble-curves/issues/244
Fixes https://github.com/paulmillr/noble-curves/issues/245

## Tests
- `npm run build`
- `node --no-warnings test/ed.test.ts`
- `node --no-warnings test/misc.test.ts`
