### PR TITLE
docs: fix Point construction demo (CURVE().type does not exist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,16 +635,16 @@ const curves = [
 for (const curve of curves) {
   const { Point } = curve;
   const { BASE, ZERO, Fp, Fn } = Point;
-  const info = Point.CURVE?.();
   const p = BASE.multiply(2n);
 
-  // Initialization
-  if (info?.type === 'weierstrass') {
-    // projective (homogeneous) coordinates: (X, Y, Z) ∋ (x=X/Z, y=Y/Z)
-    const p_ = new Point(BASE.X, BASE.Y, BASE.Z);
-  } else if (info?.type === 'edwards') {
-    // extended coordinates: (X, Y, Z, T) ∋ (x=X/Z, y=Y/Z)
+  // Initialization. Edwards points carry a T coordinate, weierstrass ones do not,
+  // so the coordinate system is detected from the point itself.
+  if (BASE.T !== undefined) {
+    // edwards extended coordinates: (X, Y, Z, T) ∋ (x=X/Z, y=Y/Z)
     const p_ = new Point(BASE.X, BASE.Y, BASE.Z, BASE.T);
+  } else {
+    // weierstrass projective (homogeneous) coordinates: (X, Y, Z) ∋ (x=X/Z, y=Y/Z)
+    const p_ = new Point(BASE.X, BASE.Y, BASE.Z);
   }
 
   // Math


### PR DESCRIPTION
closes #255

### what

The "Elliptic curve Point math" example gates Point construction on `Point.CURVE()?.type`, but `CURVE()` returns `WeierstrassOpts`/`EdwardsOpts` (`{ p, n, h, a, b|d, Gx, Gy }`) with no `type` field - `'weierstrass'|'edwards'` is only a parameter of `createCurveFields`, never stored on the returned object. So `info.type` is `undefined` and neither branch runs; the construction demo is dead code.

### how

Detect the coordinate system from the point itself - edwards points carry a `T` coordinate, weierstrass ones do not:

```js
if (BASE.T !== undefined) {
  const p_ = new Point(BASE.X, BASE.Y, BASE.Z, BASE.T); // edwards extended
} else {
  const p_ = new Point(BASE.X, BASE.Y, BASE.Z);         // weierstrass projective
}
```

### verified

```
secp256k1(weierstrass) -> reconstructed BASE, equals BASE? true
ed25519(edwards)       -> reconstructed BASE, equals BASE? true
```
