### PR TITLE
Add isCompressed param to ECDSA/ECDH keygen()

### DIFF
--- a/src/abstract/curve.ts
+++ b/src/abstract/curve.ts
@@ -16,7 +16,6 @@ import {
   isBytes,
   isPosBig,
   validateObject,
-  type Signer,
   type TArg,
   type TRet,
 } from '../utils.ts';
@@ -1054,7 +1053,10 @@ export function createCurveFields<T>(
   return { CURVE, Fp, Fn } as TRet<FpFn<T> & { CURVE: ValidCurveParams<T> }>;
 }
 
-type KeygenFn = (seed?: Uint8Array) => { secretKey: Uint8Array; publicKey: Uint8Array };
+type KeygenFn = (
+  seed?: Uint8Array,
+  isCompressed?: boolean
+) => { secretKey: Uint8Array; publicKey: Uint8Array };
 /**
  * @param randomSecretKey - Secret-key generator.
  * @param getPublicKey - Public-key derivation helper.
@@ -1067,14 +1069,20 @@ type KeygenFn = (seed?: Uint8Array) => { secretKey: Uint8Array; publicKey: Uint8
  * import { p256 } from '@noble/curves/nist.js';
  * const keygen = createKeygen(p256.utils.randomSecretKey, p256.getPublicKey);
  * const pair = keygen();
+ * const uncompressed = keygen(undefined, false).publicKey;
  * ```
  */
 export function createKeygen(
   randomSecretKey: Function,
-  getPublicKey: TArg<Signer['getPublicKey']>
+  // `isCompressed` is only meaningful for curves whose getPublicKey supports it
+  // (e.g. weierstrass/ECDSA); other curves' getPublicKey simply ignore the extra arg.
+  getPublicKey: TArg<(secretKey: Uint8Array, isCompressed?: boolean) => Uint8Array>
 ): TRet<KeygenFn> {
-  return function keygen(seed?: TArg<Uint8Array>) {
+  return function keygen(seed?: TArg<Uint8Array>, isCompressed?: boolean) {
     const secretKey = randomSecretKey(seed) as TRet<Uint8Array>;
-    return { secretKey, publicKey: getPublicKey(secretKey) as TRet<Uint8Array> };
+    return {
+      secretKey,
+      publicKey: getPublicKey(secretKey, isCompressed) as TRet<Uint8Array>,
+    };
   };
 }

--- a/src/abstract/weierstrass.ts
+++ b/src/abstract/weierstrass.ts
@@ -386,9 +386,13 @@ export interface ECDH {
   /**
    * Generate a secret/public key pair.
    * @param seed - Optional seed material.
+   * @param isCompressed - Whether publicKey is compressed SEC1 bytes. Defaults to true.
    * @returns Secret/public key pair.
    */
-  keygen: (seed?: TArg<Uint8Array>) => { secretKey: TRet<Uint8Array>; publicKey: TRet<Uint8Array> };
+  keygen: (
+    seed?: TArg<Uint8Array>,
+    isCompressed?: boolean
+  ) => { secretKey: TRet<Uint8Array>; publicKey: TRet<Uint8Array> };
   /**
    * Derive the public key from a secret key.
    * @param secretKey - Secret key bytes.

--- a/test/ecdsa.test.ts
+++ b/test/ecdsa.test.ts
@@ -152,6 +152,29 @@ describe('ECDSA', () => {
   });
 });
 
+describe('keygen isCompressed', () => {
+  for (const name in ECDSA) {
+    const C = ECDSA[name];
+    it(name, () => {
+      // Default (and explicit true) keygen() output must match getPublicKey()'s own default.
+      const { secretKey, publicKey } = C.keygen();
+      eql(publicKey, C.getPublicKey(secretKey));
+      eql(publicKey, C.getPublicKey(secretKey, true));
+      eql(publicKey.length, C.lengths.publicKey);
+
+      // isCompressed=false must produce the uncompressed public key for the same secretKey.
+      const seed = new Uint8Array(C.lengths.seed ?? C.lengths.secretKey).fill(9);
+      const compressed = C.keygen(seed, true);
+      const uncompressed = C.keygen(seed, false);
+      eql(compressed.secretKey, uncompressed.secretKey, 'same seed -> same secretKey');
+      eql(compressed.publicKey, C.getPublicKey(compressed.secretKey, true));
+      eql(compressed.publicKey.length, C.lengths.publicKey);
+      eql(uncompressed.publicKey, C.getPublicKey(compressed.secretKey, false));
+      eql(uncompressed.publicKey.length, C.lengths.publicKeyUncompressed);
+    });
+  }
+});
+
 describe('weierstrass ECDH', () => {
   const makeDh = () =>
     ecdh(weierstrass({ p: 17n, n: 257n, h: 1n, a: 2n, b: 2n, Gx: 5n, Gy: 1n }), {


### PR DESCRIPTION
Closes #204

`keygen()` always calls `getPublicKey()` with its default (`isCompressed = true`), so getting an uncompressed public key currently requires a separate call after `keygen()`:

```ts
const { secretKey } = p256.keygen();
const uncompressedPub = p256.getPublicKey(secretKey, false); // extra call
```

## What changed

Added an optional `isCompressed` param to `keygen(seed?, isCompressed?)`, forwarded through `createKeygen()` to the underlying `getPublicKey`:

```ts
const { secretKey, publicKey } = p256.keygen(undefined, false); // uncompressed directly
```

This mirrors the `isCompressed` convention already used elsewhere in the same file (`getPublicKey(secretKey, isCompressed)`, `getSharedSecret(..., isCompressed)`, `Point.toBytes(isCompressed)`/`toHex(isCompressed)`), so the new param follows an existing pattern rather than introducing a new one.

## Scope

Only `ECDH`/`ECDSA` `keygen()` (weierstrass curves) gained the param, since only their `getPublicKey` has a compressed/uncompressed distinction. Edwards (ed25519/ed448), Montgomery (x25519/x448), and secp256k1's Schnorr `keygen()` are structurally unaffected — their `getPublicKey` has no `isCompressed` concept, so passing the extra optional arg through `createKeygen` is a no-op for them (confirmed via the full test suite).

## Testing

- Added a `keygen isCompressed` test in `test/ecdsa.test.ts`, covering every curve in the existing `ECDSA` test matrix (P192/P224/P256/P384/P521/secp256k1/brainpoolP256r1/brainpoolP384r1/brainpoolP512r1): verifies `keygen()`'s default matches `getPublicKey()`'s default, and that `keygen(seed, false)` produces the correct-length uncompressed key for the same secretKey `keygen(seed, true)` produces compressed for.
- `npx tsc --noEmit` passes
- `npm run check` (`jsbt-check`) — the `bytes` convention check passes (parameter type wrapped in `TArg<...>` per the existing convention)
- `npx prettier --check` passes on changed files
- Full suite: `node --no-warnings test/index.ts` → 2534/2534 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)